### PR TITLE
Fixed authentication issue?

### DIFF
--- a/lib/dm-mongo-adapter/adapter.rb
+++ b/lib/dm-mongo-adapter/adapter.rb
@@ -248,9 +248,9 @@ module DataMapper
         unless defined?(@database)
           @database = connection.db(@options[:database])
 
-          if @options[:username]
+          if @options[:user]
             begin
-              @database.authenticate(@options[:username], @options[:password])
+              @database.authenticate(@options[:user], @options[:password])
             rescue ::Mongo::AuthenticationError
               raise ConnectionError,
                 'MongoDB did not recognize the given username and/or ' \


### PR DESCRIPTION
Hi solnic,

I just played around with your dm-mongo-adapter. Tried to ran the specs, but always got authentication problems.

The connection options where providing only @options[:user], the code used @options[:username], so all the time nil was passed to mongo authentication.

Feel free to pull or comment my submission!

Regards,

Markus
